### PR TITLE
Added Hostname To Agent Name

### DIFF
--- a/org.healthwise.newrelic.filewatcher/PluginAgent.cs
+++ b/org.healthwise.newrelic.filewatcher/PluginAgent.cs
@@ -9,6 +9,7 @@ namespace org.healthwise.newrelic.filewatcher
     {
         private readonly string _name;
         private readonly string _path;
+        private readonly string _hostname;
         private readonly Logger _log = Logger.GetLogger(typeof(PluginAgent).Name);
 
 
@@ -16,6 +17,8 @@ namespace org.healthwise.newrelic.filewatcher
         {
             _name = name;
             _path = path;
+
+            _hostname = System.Environment.MachineName;
         }
 
         public override void PollCycle()
@@ -35,7 +38,7 @@ namespace org.healthwise.newrelic.filewatcher
 
         public override string GetAgentName()
         {
-            return this._name;
+            return $"{this._name} - {this._hostname}";
         }
 
         public override string Guid

--- a/org.healthwise.newrelic.filewatcher/Properties/AssemblyInfo.cs
+++ b/org.healthwise.newrelic.filewatcher/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]


### PR DESCRIPTION
This will provide more context to the alert messages, by showing which host the lock file is on.